### PR TITLE
Initialize constraints objects with local DoFs

### DIFF
--- a/nonlinear-poro-viscoelasticity.cc
+++ b/nonlinear-poro-viscoelasticity.cc
@@ -5031,8 +5031,15 @@ class OgdenIso : public Material_Hyperelastic < dim, NumberType >
 
         const bool apply_dirichlet_bc = (it_nr_IN == 0);
 
+      
+        
         if (apply_dirichlet_bc) {
           constraints.clear();
+          
+          const IndexSet& locally_relevant_dofs = 
+                DoFTools::extract_locally_relevant_dofs(dof_handler_ref);
+          constraints.reinit(dof_handler_ref.locally_owned_dofs(),
+                       locally_relevant_dofs);
           make_dirichlet_constraints(constraints);  
         } else {
         	for (unsigned int i=0; i<dof_handler_ref.n_dofs(); ++i)
@@ -5173,6 +5180,9 @@ class OgdenIso : public Material_Hyperelastic < dim, NumberType >
                                                     mpi_communicator);
 
         hanging_node_constraints.clear();
+        const IndexSet &locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler_ref);
+        hanging_node_constraints.reinit(dof_handler_ref.locally_owned_dofs(),
+                                                    locally_relevant_dofs);
         DoFTools::make_hanging_node_constraints(dof_handler_ref,hanging_node_constraints);
         hanging_node_constraints.close();
 


### PR DESCRIPTION
Related to https://github.com/dealii-X/dealii-X/issues/10

When running in parallel in Debug mode, the following assertion is thrown:
```

--------------------------------------------------------
An error occurred in line <2857> of file </home/marco/Desktop/Research/dealii/include/deal.II/lac/affine_constraints.templates.h> in function
    void dealii::AffineConstraints<number>::distribute(VectorType&) const [with VectorType = dealii::TrilinosWrappers::MPI::BlockVector; number = double]
The violated condition was: 
    local_lines != IndexSet()
Additional information: 
    You are using the AffineConstraints class in a program that is running
    in parallel. In this case, it is inefficient to store all constraints:
    This class should really only store constraints for those degrees of
    freedom that are locally relevant. It is considered a bug not to do
    that. Please call either the constructor of this class, or one of its
    reinit() functions that provide this class with index sets of the
    locally owned and the locally relevant degrees of freedom.

Stacktrace:
-----------
#0  /home/marco/Desktop/libs/dealii_master/lib/libdeal_II.g.so.9.7.0-pre: void dealii::AffineConstraints<double>::distribute<dealii::TrilinosWrappers::MPI::BlockVector>(dealii::TrilinosWrappers::MPI::BlockVector&) const
#1  nonlinear-poro-viscoelasticity: NonLinearPoroViscoElasticity::Solid<3>::solve_nonlinear_timestep(dealii::TrilinosWrappers::MPI::BlockVector&)
#2  nonlinear-poro-viscoelasticity: NonLinearPoroViscoElasticity::Solid<3>::run()
#3  nonlinear-poro-viscoelasticity: main
--------------------------------------------------------
```

This PR calls the initialization function described in the error message. I have tested this only with `parameter_files/parameters_small_Q2P1.prm`